### PR TITLE
Generate a type error if user tries to use `keys entity` without using `Only`

### DIFF
--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -26,18 +26,18 @@ data List a
 
 type family DependenciesTypeInstance nodeTy depsTy where
   DependenciesTypeInstance nodeTy depsTy =
-    'Text "`type Dependencies " ':<>: 'ShowType nodeTy ':<>:
-    'Text " = " ':<>: 'ShowType depsTy ':<>: 'Text "`"
+    'Text "‘type Dependencies " ':<>: 'ShowType nodeTy ':<>:
+    'Text " = " ':<>: 'ShowType depsTy ':<>: 'Text "’"
 
 -- Walk through the fields of our node and match them up with fields from the dependencies.
 type family FindMatches nodeTy depsTy as ds where
   -- Excess dependencies
   FindMatches nodeTy depsTy () (d, ds) =
     TypeError
-      ( 'Text "Excess dependency `" ':<>: 'ShowType d ':<>:
-        'Text "` in " ':$$: DependenciesTypeInstance nodeTy depsTy ':$$:
-        'Text "Ordering of dependencies must match their occurrence in the target type `" ':<>:
-        'ShowType nodeTy ':<>: 'Text "`"
+      ( 'Text "Excess dependency ‘" ':<>: 'ShowType d ':<>:
+        'Text "’ in " ':$$: DependenciesTypeInstance nodeTy depsTy ':$$:
+        'Text "Ordering of dependencies must match their occurrence in the target type ‘" ':<>:
+        'ShowType nodeTy ':<>: 'Text "’"
       )
 
   -- No dependencies

--- a/graphula-persistent/src/Graphula/Persist.hs
+++ b/graphula-persistent/src/Graphula/Persist.hs
@@ -4,6 +4,9 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Graphula.Persist (persistGraph, keys, PersistRecord) where
 
 import Graphula
@@ -11,6 +14,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans.Reader
 import Database.Persist
 import Database.Persist.Sql
+import GHC.TypeLits (TypeError, ErrorMessage(..))
 
 persistGraph
   :: (SqlBackendCanWrite backend, MonadIO m, MonadIO n)
@@ -34,7 +38,14 @@ class EntityKeys a where
   type Keys a
   keys :: a -> Keys a
 
-instance EntityKeys (Entity a) where
+instance
+  ( TypeError
+    ( 'Text "Cannot use naked ‘" ':<>: 'ShowType (Entity a) ':<>:
+      'Text "’ as argument to ‘keys’." ':$$:
+      'Text "Did you mean ‘Only (" ':<>:
+      'ShowType (Entity a) ':<>: 'Text ")’?"
+    )
+  ) => EntityKeys (Entity a) where
   type Keys (Entity a) = Key a
   keys = entityKey
 


### PR DESCRIPTION
I think we should either remove `instance EntityKeys (Entity a)`, or, as this PR does, make it emit a helpful error to the user. Here, suppose I failed to use `Only` in both the `HasDependencies` instance for `BT` and the call to `keys`. I get the first error because there isn't a `Generic` instance for `Key AT`, but the second error comes from the spurious instance:
```plaintext
/home/chris/code/graphula/graphula-persistent/README.lhs:71:10: error:
    • Couldn't match type ‘Rep (Key AT)’ with ‘M1 D c0 f0’
        arising from a use of ‘Graphula.$dmdependsOn’
      The type variables ‘c0’, ‘f0’ are ambiguous
    • In the expression: Graphula.$dmdependsOn @BT
      In an equation for ‘dependsOn’:
          dependsOn = Graphula.$dmdependsOn @BT
      In the instance declaration for ‘HasDependencies BT’
             
/home/chris/code/graphula/graphula-persistent/README.lhs:113:23: error:
    • Cannot use naked ‘Entity AT’ as argument to ‘keys’.
      Did you mean ‘Only (Entity AT)’?
    • In the second argument of ‘($)’, namely ‘keys a’
      In a stmt of a 'do' block: b <- nodeWith $ keys a
      In the second argument of ‘($)’, namely
        ‘do { a <- node;
              b <- nodeWith $ keys a;
              c <- nodeEditWith (keys (a, b)) $ \ n -> n {cTC = "spanish"};
              Entity d1Id _ <- nodeWith $ keys $ only c;
              .... }’
```

If the user wrote a correct `HasDependencies` instance, but called `keys a`, they still get the second error, but I suspect that will be a less common occurrence than not using `Only` at all.


I'm also fine to just remove the instance entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphula/6)
<!-- Reviewable:end -->
