### PR TITLE
Implement tfausak's suggestion to export key = keys . only

### DIFF
--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -254,8 +254,9 @@ tryInsert maxAttempts currentAttempts source
       Just a -> pure a
       Nothing -> tryInsert maxAttempts (succ currentAttempts) source
 
--- For entities that only have one dependency
-newtype Only a = Only { fromOnly :: a }
+-- For entities that only have one dependency. Uses data instead of newtype to
+-- match laziness of builtin tuples
+data Only a = Only { fromOnly :: a }
   deriving (Eq, Show, Ord, Generic, Functor, Foldable, Traversable)
 
 only :: a -> Only a

--- a/graphula-persistent/README.lhs
+++ b/graphula-persistent/README.lhs
@@ -64,7 +64,7 @@ main =
 
     let makeSimpleGraph = do
           a <- node
-          b <- nodeWith . keys $ only a
+          b <- nodeWith $ key a
           c <- nodeEditWith (keys (a, b)) $ \n ->
             n { cTC = "spanish" }
           pure (a, b, c)
@@ -82,8 +82,8 @@ main =
 
     it "should respect unique constraints" $ withGraph $ do
       (_, _, c) <- makeSimpleGraph
-      d1 <- nodeWith . keys $ only c
-      d2 <- nodeWith . keys $ only c
+      d1 <- nodeWith $ key c
+      d2 <- nodeWith $ key c
       liftIO $ do
         (persistedD1, persistedD2) <- runTestDB $ do
           Just persistedD1 <- getEntity $ entityKey d1

--- a/graphula-persistent/src/Graphula/Persist.hs
+++ b/graphula-persistent/src/Graphula/Persist.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-module Graphula.Persist (persistGraph, keys, PersistRecord) where
+module Graphula.Persist (persistGraph, key, keys, PersistRecord) where
 
 import Graphula
 import Control.Monad.IO.Class
@@ -26,7 +26,7 @@ persistGraph runDB = \case
       mKey <- insertUnique n
       case mKey of
         Nothing -> pure Nothing
-        Just key -> getEntity key
+        Just key' -> getEntity key'
     next x
 
 class (PersistEntity a, PersistEntityBackend a ~ SqlBackend, PersistStoreWrite backend, PersistUniqueWrite backend) => PersistRecord backend a where
@@ -48,6 +48,9 @@ instance
   ) => EntityKeys (Entity a) where
   type Keys (Entity a) = Key a
   keys = entityKey
+
+key :: Entity a -> Only (Key a)
+key = keys . only
 
 instance EntityKeys (Only (Entity a)) where
   type Keys (Only (Entity a)) = Only (Key a)


### PR DESCRIPTION
Also make `Only` as lazy as builtin tuples. The former is kind of a nice-to-have, the latter is a we-should-probably-have.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/frontrowed/graphula/9)
<!-- Reviewable:end -->
