### PR TITLE
Add constraint based editing

### DIFF
--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -122,11 +122,11 @@ loggingAndReplaySpec = do
     logFile = "test.graphula"
     -- We'd typically use `runGraphulaLogged` which utilizes a temp file.
     failingGraph = runGraphulaT runDB . runGraphulaLoggedWithFileT logFile $ do
-      Entity _ a <- nodeEdit @A $ \n ->
+      Entity _ a <- node @A . edit $ \n ->
         n {aA = "success"}
       liftIO $ aA a `shouldBe` "failed"
     replayGraph = runGraphulaT runDB . runGraphulaReplayT logFile $ do
-      Entity _ a <- node @A
+      Entity _ a <- node @A Just
       liftIO $ aA a `shouldBe` "success"
 
   failingGraph
@@ -141,12 +141,12 @@ simpleSpec :: IO ()
 simpleSpec =
   runGraphulaT runDB $ do
     -- Declare the graph at the term level
-    Entity aId _ <- node @A
+    Entity aId _ <- node @A Just
     liftIO $ putStrLn "A"
-    Entity bId b <- nodeWith @B (only aId)
+    Entity bId b <- nodeWith @B (only aId) Just
     -- Type application is not necessary, but recommended for clarity.
     liftIO $ putStrLn "B"
-    Entity _ c <- nodeEditWith @C (aId, bId) $ \n ->
+    Entity _ c <- nodeWith @C (aId, bId) . edit $ \n ->
       n { cC = "spanish" }
     liftIO $ putStrLn "C"
 
@@ -172,7 +172,7 @@ insertionFailureSpec :: IO ()
 insertionFailureSpec = do
   let
     failingGraph =  runGraphulaT runDB . runGraphulaFailT $ do
-      Entity _ _ <- node @A
+      Entity _ _ <- node @A Just
       pure ()
   failingGraph
     `shouldThrow` (== (GenerationFailureMaxAttempts (typeRep $ Proxy @A)))


### PR DESCRIPTION
Based on https://github.com/frontrowed/graphula/issues/22

`suchThat` is a powerful tool in property based testing. Allowing for
patterns like `suchThat` enables more powerful testing with `graphula`.
This is a proof of concept that proposes changing `edit` to a combinator
of type `a -> Maybe a` instead of `a -> a`. With the addition of `Maybe`
we can allow for failure in an edit, which leads to constraint based
combinators like `suchThat`.

```hs
edit :: (a -> a) -> a -> Maybe a
edit f = Just . f

suchThat :: (a -> Bool) -> a -> Maybe a
suchThat f x = x <$ guard (f x)
```