### PR TITLE
Add example to run the lhs file

### DIFF
--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -193,3 +193,5 @@ runDB f = runSqlite "test.db" $ do
   f
 ```
 -->
+
+** This literate Haskell file is using the [markdown-unlit](https://github.com/sol/markdown-unlit) package. You can run the examples in this file by invoking `stack exec -- ghci -pgmL markdown-unlit graphula-core/README.lhs` in your terminal. You might need to install missing packages (`persistent-sqlite` and `persistent-template`).


### PR DESCRIPTION
I added a short note to the bottom of the lhs file describing how the
user could run the examples in this file. This could have helped me, as
I was unfamiliar with the `markdown-unlit` package.