### PR TITLE
Ensure embedded keys are used to check uniqueness

### DIFF
--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -155,9 +155,9 @@ class EntityKeyGen a where
   -- compound key since persistent doesn't check that the compound
   -- key and the columns in the node are actually the same.
   --
-  emplaceKey :: a -> Key a -> a
-  default emplaceKey :: EmplaceKeyTagged (KeyType a) a => a -> Key a -> a
-  emplaceKey = emplaceKeyTagged (Proxy @(KeyType a))
+  embedKey :: a -> Key a -> a
+  default embedKey :: EmbedKeyTagged (KeyType a) a => a -> Key a -> a
+  embedKey = embedKeyTagged (Proxy @(KeyType a))
 
 class MonadGraphulaBackend m where
   type Logging m :: * -> Constraint
@@ -523,7 +523,7 @@ attemptsToInsertWith attempts source
   | otherwise = do
     value <- source
     mKey <- liftIO $ generate genEntityKey
-    let updated = maybe value (emplaceKey value) mKey
+    let updated = maybe value (embedKey value) mKey
     insert mKey updated >>= \case
       Just a -> pure a
       Nothing -> pred attempts `attemptsToInsertWith` source

--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -137,12 +137,12 @@ instance GHasDependenciesRecursive (Proxy ('[] :: [Match *])) () () where
 data KeyTag = SimpleKey | CompositeKey
 
 -- | Strategy for emplacing a key in its record
-class EmplaceKeyTagged (k :: KeyTag) a where
-  emplaceKeyTagged :: proxy k -> a -> Key a -> a
+class EmbedKeyTagged (k :: KeyTag) a where
+  embedKeyTagged :: proxy k -> a -> Key a -> a
 
 -- | By default, a key lives outside of its record
-instance EmplaceKeyTagged 'SimpleKey a where
-  emplaceKeyTagged _ a _ = a
+instance EmbedKeyTagged 'SimpleKey a where
+  embedKeyTagged _ a _ = a
 
 -- | A composite key is made up of fields from within its record
 instance
@@ -150,8 +150,8 @@ instance
   , HasEot (Key a)
   , GHasDependencies (Proxy a) (Proxy (Key a)) (Eot a) (Eot (Key a))
   )
-  => EmplaceKeyTagged 'CompositeKey a where
-  emplaceKeyTagged _ a key = fromEot $ genericDependsOn
+  => EmbedKeyTagged 'CompositeKey a where
+  embedKeyTagged _ a key = fromEot $ genericDependsOn
     (Proxy :: Proxy a)
     (Proxy :: Proxy (Key a))
     (toEot a)

--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -9,8 +9,7 @@
 
 module Graphula.Internal where
 
-import Database.Persist (Key)
-import Generics.Eot (HasEot(..), Proxy(..), Void)
+import Generics.Eot (Proxy(..), Void)
 import GHC.TypeLits (ErrorMessage(..), TypeError)
 
 data Match t
@@ -132,27 +131,3 @@ instance
 -- instance for nullary constructors
 instance GHasDependenciesRecursive (Proxy ('[] :: [Match *])) () () where
   genericDependsOnRecursive _ _ _ = ()
-
--- | Used for @'KeyType'@ type instances
-data KeyTag = SimpleKey | CompositeKey
-
--- | Strategy for emplacing a key in its record
-class EmbedKeyTagged (k :: KeyTag) a where
-  embedKeyTagged :: proxy k -> a -> Key a -> a
-
--- | By default, a key lives outside of its record
-instance EmbedKeyTagged 'SimpleKey a where
-  embedKeyTagged _ a _ = a
-
--- | A composite key is made up of fields from within its record
-instance
-  ( HasEot a
-  , HasEot (Key a)
-  , GHasDependencies (Proxy a) (Proxy (Key a)) (Eot a) (Eot (Key a))
-  )
-  => EmbedKeyTagged 'CompositeKey a where
-  embedKeyTagged _ a key = fromEot $ genericDependsOn
-    (Proxy :: Proxy a)
-    (Proxy :: Proxy (Key a))
-    (toEot a)
-    (toEot key)


### PR DESCRIPTION
When a node implements `EntityKeyGen` such that `genEntityKey` returns `Just`, we use `insertKey` to write the node to the database. However, if the key is a composite key, `persistent` keeps those values in the record itself, and `insertKey` doesn't ensure that the key argument and the record agree on those values.

This is bad.

Instead of trying to bake this into the API, we just do the right thing at runtime. We do the following:

1. Generate a node
2. Optionally generate a key
3. Check - did we generate a key, and does this type have a `Primary` definition?
    1. No! We're done! Insert away!
    2. Yes!
        1. Convert the record to an association list of `[(HaskellName, PersistValue)]`
        2. Convert the key to an association list of `[(HaskellName, PersistValue)]`
        3. Replace any values in the record list with values from the key list where the names match up
        4. Insert!

This is a little wacky, but it's basically what `persistent` does on write and read anyway. We'll only pay for it with entities that implement `genEntityKey` and declare `Primary`, so I don't think it's much of a problem.

I did go ahead and merge `HasDependencies` and `EntityKeyGen`.