### PR TITLE
Simplify node API while expanding the set of supported relationships

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,14 @@
+---
+restylers:
+  - brittany:
+      image: restyled/restyler-brittany:v0.12.0.0
+      include:
+        - "**/*.hs"
+  - stylish-haskell:
+      include:
+        - "**/*.hs"
+
+comments: false
+
+labels:
+  - restyled

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,57 @@
+---
+steps:
+  - simple_align:
+      cases: false
+      top_level_patterns: false
+      records: false
+  - imports:
+      align: none
+      list_align: after_alias
+      pad_module_names: false
+      long_list_align: new_line_multiline
+      empty_list_align: right_after
+      list_padding: 2
+      separate_lists: false
+      space_surround: false
+  - language_pragmas:
+      style: vertical
+      align: false
+      remove_redundant: false
+  - trailing_whitespace: {}
+columns: 80
+newline: native
+language_extensions:
+  - BangPatterns
+  - ConstraintKinds
+  - DataKinds
+  - DeriveAnyClass
+  - DeriveDataTypeable
+  - DeriveGeneric
+  - DerivingStrategies
+  - DoAndIfThenElse
+  - EmptyDataDecls
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - KindSignatures
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - NamedFieldPuns
+  - NoImplicitPrelude
+  - NoMonomorphismRestriction
+  - OverloadedStrings
+  - PolyKinds
+  - QuasiQuotes
+  - Rank2Types
+  - RecordWildCards
+  - ScopedTypeVariables
+  - StandaloneDeriving
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications
+  - TypeFamilies
+  - TypeOperators
+  - ViewPatterns

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-graphula-core/README.lhs
+graphula-core/test/README.lhs

--- a/brittany.yaml
+++ b/brittany.yaml
@@ -1,0 +1,77 @@
+---
+conf_debug:
+  dconf_roundtrip_exactprint_only: false
+  dconf_dump_bridoc_simpl_par: false
+  dconf_dump_ast_unknown: false
+  dconf_dump_bridoc_simpl_floating: false
+  dconf_dump_config: false
+  dconf_dump_bridoc_raw: false
+  dconf_dump_bridoc_final: false
+  dconf_dump_bridoc_simpl_alt: false
+  dconf_dump_bridoc_simpl_indent: false
+  dconf_dump_annotations: false
+  dconf_dump_bridoc_simpl_columns: false
+  dconf_dump_ast_full: false
+conf_forward:
+  options_ghc:
+    - -XBangPatterns
+    - -XConstraintKinds
+    - -XDataKinds
+    - -XDeriveDataTypeable
+    - -XDeriveGeneric
+    - -XDoAndIfThenElse
+    - -XEmptyDataDecls
+    - -XFlexibleContexts
+    - -XFlexibleInstances
+    - -XFunctionalDependencies
+    - -XGADTs
+    - -XKindSignatures
+    - -XLambdaCase
+    - -XMultiParamTypeClasses
+    - -XMultiWayIf
+    - -XNamedFieldPuns
+    - -XNoImplicitPrelude
+    - -XNoMonomorphismRestriction
+    - -XOverloadedStrings
+    - -XPolyKinds
+    - -XQuasiQuotes
+    - -XRank2Types
+    - -XRecordWildCards
+    - -XScopedTypeVariables
+    - -XStandaloneDeriving
+    - -XTemplateHaskell
+    - -XTupleSections
+    - -XTypeApplications
+    - -XTypeFamilies
+    - -XTypeOperators
+    - -XViewPatterns
+conf_errorHandling:
+  econf_ExactPrintFallback: ExactPrintFallbackModeInline
+  econf_Werror: false
+  econf_omit_output_valid_check: false
+  econf_produceOutputOnErrors: false
+conf_preprocessor:
+  ppconf_CPPMode: CPPModeAbort
+  ppconf_hackAroundIncludes: false
+conf_obfuscate: false
+conf_roundtrip_exactprint_only: false
+conf_version: 1
+conf_layout:
+  lconfig_reformatModulePreamble: true
+  lconfig_altChooser:
+    tag: AltChooserBoundedSearch
+    contents: 3
+  lconfig_allowSingleLineExportList: false
+  lconfig_importColumn: 60
+  lconfig_hangingTypeSignature: false
+  lconfig_importAsColumn: 50
+  lconfig_alignmentLimit: 1
+  lconfig_indentListSpecial: true
+  lconfig_indentAmount: 2
+  lconfig_alignmentBreakOnMultiline: true
+  lconfig_cols: 80
+  lconfig_indentPolicy: IndentPolicyLeft
+  lconfig_indentWhereSpecial: true
+  lconfig_columnAlignMode:
+    tag: ColumnAlignModeDisabled
+    contents: 0.7

--- a/graphula-core/README.lhs
+++ b/graphula-core/README.lhs
@@ -122,11 +122,11 @@ loggingAndReplaySpec = do
     logFile = "test.graphula"
     -- We'd typically use `runGraphulaLogged` which utilizes a temp file.
     failingGraph = runGraphulaT runDB . runGraphulaLoggedWithFileT logFile $ do
-      Entity _ a <- nodeEdit @A $ \n ->
+      Entity _ a <- root @A $ edit $ \n ->
         n {aA = "success"}
       liftIO $ aA a `shouldBe` "failed"
     replayGraph = runGraphulaT runDB . runGraphulaReplayT logFile $ do
-      Entity _ a <- node @A
+      Entity _ a <- root @A mempty
       liftIO $ aA a `shouldBe` "success"
 
   failingGraph
@@ -141,12 +141,12 @@ simpleSpec :: IO ()
 simpleSpec =
   runGraphulaT runDB $ do
     -- Declare the graph at the term level
-    Entity aId _ <- node @A
+    Entity aId _ <- root @A mempty
     liftIO $ putStrLn "A"
-    Entity bId b <- nodeWith @B (only aId)
+    Entity bId b <- node @B (only aId) mempty
     -- Type application is not necessary, but recommended for clarity.
     liftIO $ putStrLn "B"
-    Entity _ c <- nodeEditWith @C (aId, bId) $ \n ->
+    Entity _ c <- node @C (aId, bId) $ edit $ \n ->
       n { cC = "spanish" }
     liftIO $ putStrLn "C"
 
@@ -172,10 +172,10 @@ insertionFailureSpec :: IO ()
 insertionFailureSpec = do
   let
     failingGraph =  runGraphulaT runDB . runGraphulaFailT $ do
-      Entity _ _ <- node @A
+      Entity _ _ <- root @A mempty
       pure ()
   failingGraph
-    `shouldThrow` (== (GenerationFailureMaxAttempts (typeRep $ Proxy @A)))
+    `shouldThrow` (== (GenerationFailureMaxAttemptsToInsert (typeRep $ Proxy @A)))
 ```
 
 <!--

--- a/graphula-core/README.md
+++ b/graphula-core/README.md
@@ -1,1 +1,1 @@
-README.lhs
+test/README.lhs

--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -6,8 +6,6 @@ extra-source-files:
   - ../stack.yaml
 
 dependencies:
-  - HUnit
-  - QuickCheck
   - aeson
   - base
   - bytestring
@@ -16,8 +14,10 @@ dependencies:
   - exceptions
   - free
   - generics-eot
+  - HUnit
   - mtl
   - persistent
+  - QuickCheck
   - semigroups
   - temporary
   - transformers
@@ -42,13 +42,19 @@ tests:
   readme:
     main: README.lhs
     ghc-options: -Wall -pgmL markdown-unlit
+    source-dirs:
+      - test
     dependencies:
       - base
       - graphula-core
       - hspec
+      - http-api-data
       - markdown-unlit
+      - monad-logger
+      - path-pieces
+      - persistent-arbitrary
       - persistent-sqlite
       - persistent-template
-      - persistent-arbitrary
-      - monad-logger
       - resourcet
+      - text
+      - uuid

--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -18,6 +18,7 @@ dependencies:
   - generics-eot
   - mtl
   - persistent
+  - semigroups
   - temporary
   - transformers
   - unliftio

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -37,28 +37,28 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Graphula
-  ( -- * Graph Declaration
+  ( -- ** Graph Declaration
     root
   , node
-    -- * Node options
+  , GraphulaNode
+  , GraphulaContext
+    -- ** Node options
   , NodeOptions
   , edit
   , suchThat
   , primaryKey
-  , GraphulaNode
-  , GraphulaContext
-  -- * Declaring Dependencies
+    -- ** Declaring Dependencies
   , HasDependencies(..)
-  -- ** Singular Dependencies
+    -- *** Singular Dependencies
   , Only(..)
   , only
-  -- * The Graph Monad
-  -- ** Type Classes
+    -- ** The Graph Monad
+    -- *** Type Classes
   , MonadGraphula
   , MonadGraphulaBackend(..)
   , MonadGraphulaFrontend(..)
   , EntityKeyGen(..)
-  -- ** Backends
+    -- *** Backends
   , runGraphulaT
   , GraphulaT
   , runGraphulaLoggedT
@@ -66,12 +66,12 @@ module Graphula
   , GraphulaLoggedT
   , runGraphulaReplayT
   , GraphulaReplayT
-  -- ** Frontends
+    -- *** Frontends
   , runGraphulaIdempotentT
   , GraphulaIdempotentT
-  -- * Extras
+    -- ** Extras
   , NoConstraint
-  -- * Exceptions
+    -- ** Exceptions
   , GenerationFailure(..)
   )
 where

--- a/graphula-core/test/Graphula/UUIDKey.hs
+++ b/graphula-core/test/Graphula/UUIDKey.hs
@@ -5,18 +5,19 @@
 
 module Graphula.UUIDKey
   ( UUIDKey
-  ) where
+  )
+where
 
 import Prelude
 
-import Data.UUID (UUID)
 import Data.Aeson (FromJSON, ToJSON)
-import qualified Data.UUID as UUID
 import qualified Data.Text as Text
+import Data.UUID (UUID)
+import qualified Data.UUID as UUID
 import Database.Persist
 import Database.Persist.Sql
 import Test.QuickCheck (Arbitrary(..), getLarge)
-import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
+import Web.HttpApiData (FromHttpApiData, ToHttpApiData)
 import Web.PathPieces (PathPiece(..))
 
 -- | Example non-serial key
@@ -36,10 +37,9 @@ instance PathPiece UUIDKey where
 instance PersistField UUIDKey where
   toPersistValue = PersistText . Text.pack . UUID.toString . unUUIDKey
   fromPersistValue = \case
-    PersistText t ->
-      case UUID.fromString $ Text.unpack t of
-        Just x -> Right $ UUIDKey x
-        Nothing -> Left "Invalid UUID"
+    PersistText t -> case UUID.fromString $ Text.unpack t of
+      Just x -> Right $ UUIDKey x
+      Nothing -> Left "Invalid UUID"
     _ -> Left "Not PersistText"
 
 instance PersistFieldSql UUIDKey where

--- a/graphula-core/test/Graphula/UUIDKey.hs
+++ b/graphula-core/test/Graphula/UUIDKey.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Graphula.UUIDKey
+  ( UUIDKey
+  ) where
+
+import Prelude
+
+import Data.UUID (UUID)
+import Data.Aeson (FromJSON, ToJSON)
+import qualified Data.UUID as UUID
+import qualified Data.Text as Text
+import Database.Persist
+import Database.Persist.Sql
+import Test.QuickCheck (Arbitrary(..), getLarge)
+import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
+import Web.PathPieces (PathPiece(..))
+
+-- | Example non-serial key
+newtype UUIDKey = UUIDKey { unUUIDKey :: UUID }
+  deriving newtype (Eq, Show, Ord, Read, FromJSON, ToJSON, ToHttpApiData, FromHttpApiData)
+
+instance Arbitrary UUIDKey where
+  arbitrary = UUIDKey <$> uuid
+   where
+    uuid = UUID.fromWords <$> word <*> word <*> word <*> word
+    word = getLarge <$> arbitrary
+
+instance PathPiece UUIDKey where
+  toPathPiece = Text.pack . UUID.toString . unUUIDKey
+  fromPathPiece = fmap UUIDKey . UUID.fromString . Text.unpack
+
+instance PersistField UUIDKey where
+  toPersistValue = PersistText . Text.pack . UUID.toString . unUUIDKey
+  fromPersistValue = \case
+    PersistText t ->
+      case UUID.fromString $ Text.unpack t of
+        Just x -> Right $ UUIDKey x
+        Nothing -> Left "Invalid UUID"
+    _ -> Left "Not PersistText"
+
+instance PersistFieldSql UUIDKey where
+  sqlType _ = SqlOther "uuid"

--- a/graphula-core/test/README.lhs
+++ b/graphula-core/test/README.lhs
@@ -36,7 +36,7 @@ import GHC.Generics (Generic)
 import Graphula
 import Graphula.UUIDKey
 import Test.Hspec
-import Test.QuickCheck hiding (suchThat)
+import Test.QuickCheck
 ```
 -->
 
@@ -250,11 +250,11 @@ constraintFailureSpec = do
 or if we define a graph with an unsatisfiable predicates:
 
 ```haskell
-suchThatFailureSpec :: IO ()
-suchThatFailureSpec = do
+ensureFailureSpec :: IO ()
+ensureFailureSpec = do
   let
     failingGraph =  runGraphulaT runDB $ do
-      Entity _ _ <- node @A () $ suchThat $ \a -> a /= a
+      Entity _ _ <- node @A () $ ensure $ \a -> a /= a
       pure ()
   failingGraph
     `shouldThrow` (== (GenerationFailureMaxAttemptsToConstrain (typeRep $ Proxy @A)))
@@ -269,7 +269,7 @@ main = hspec $
     it "allows logging and replaying graphs" loggingAndReplaySpec
     it "attempts to retry node generation on insertion failure" insertionFailureSpec
     it "attempts to retry node generation on a database constraint violation" constraintFailureSpec
-    it "attempts to retry node generation on unsatisfiable predicates" suchThatFailureSpec
+    it "attempts to retry node generation on unsatisfiable predicates" ensureFailureSpec
 
 runDB :: MonadUnliftIO m => ReaderT SqlBackend (NoLoggingT (ResourceT m)) a -> m a
 runDB f = runSqlite "test.db" $ do

--- a/graphula-core/test/README.lhs
+++ b/graphula-core/test/README.lhs
@@ -126,25 +126,25 @@ instance HasDependencies C where
 ## Non Sequential Keys
 
 Graphula supports non-sequential keys with the `KeySource` associated type. To generate a key using
-its `Arbitrary` instance, use `'GenerateKey 'Arbitrary`. Non-serial keys will need to also derive
+its `Arbitrary` instance, use `'SourceArbitrary`. Non-serial keys will need to also derive
 an overlapping `Arbitrary` instance.
 
 ```haskell
 instance HasDependencies D where
-  type KeySource D = 'GenerateKey 'Arbitrary
+  type KeySource D = 'SourceArbitrary
 
 deriving instance {-# OVERLAPPING #-} Arbitrary (Key D)
 ```
 
-You can also elect to always specify an external key using `'SpecifyKey`. This means that
-calls to `node` will always require an extra argument:
+You can also elect to always specify an external key using `'SourceExternal`. This means that
+this type cannot be constructed with `node`; use `nodeKeyed` instead.
 
 ```haskell
 instance HasDependencies E where
-  type KeySource E = 'SpecifyKey
+  type KeySource E = 'SourceExternal
 ```
 
-By default, `HasDependencies` instances use `type KeySource _ = 'GenerateKey 'Default`, which means
+By default, `HasDependencies` instances use `type KeySource _ = 'SourceDefault`, which means
 that graphula will expect the database to provide a key.
 
 ## Replay And Serialization
@@ -202,7 +202,7 @@ simpleSpec =
     liftIO $ putStrLn "C"
     Entity dId _ <- node @D () mempty
     liftIO $ putStrLn "D"
-    Entity eId _ <- node @E () (EKey dId) mempty
+    Entity eId _ <- nodeKeyed @E (EKey dId) () mempty
     liftIO $ putStrLn "E"
 
     -- Do something with your data


### PR DESCRIPTION
**Breaking change**

This is a draft solution to an issue @pbrisbin noted in slack:

> so, math_question_content_{lang} 's own primary key id field is also the FK to math_questions(id)... Graphula cannot deal with this

Previously, we had (constraints elided)

```haskell
node         :: (Dependencies a ~ ())             => m (Entity a)
nodeEdit     :: (Dependencies a ~ ()) => (a -> a) -> m (Entity a)
nodeWith     ::  Dependencies a                   -> m (Entity a)
nodeEditWith ::  Dependencies a       -> (a -> a) -> m (Entity a)
```

<details>
  <summary>
    Click here for oldest stuff
  </summary>

We wanted to add a way to override an entity's primary key at the call site, but that would necessarily expand the set of bindings we'd have to export. So, I've changed the API to just:

```haskell
root :: (Dependencies a ~ ()) => NodeOptions a -> m (Entity a)
node ::  Dependencies a       -> NodeOptions a -> m (Entity a)
```

`NodeOptions a` is an opaque data type constructed by:

```haskell
mempty   ::                NodeOptions a
edit     :: (a -> a)    -> NodeOptions a
suchThat :: (a -> Bool) -> NodeOptions a
keyed    :: Key a       -> NodeOptions a
```

Note the `suchThat` constructor borrowed from @eborden 's PR #23. Multiple `NodeOptions a` values can be combined with the `Semigroup` operator `(<>)`:

```haskell
Entity schoolId _ <- root @School
  $ keyed (SchoolKey 1)
  <> edit (\s -> s { schoolName = "The School" })
```

One can avoid the extra parenthesization around the lambda with `do`:

```haskell
Entity schoolId _ <- root @School
  $ keyed (SchoolKey 1)
  <> do edit $ \s -> s { schoolName = "The School" }
```

Or by using `mconcat`:

```haskell
Entity schoolId _ <- root @School $ mconcat
  [ keyed (SchoolKey 1)
  , edit $ \s -> s { schoolName = "The School" }
  ]
```

I don't expect the `keyed` option to be used very often. The common case will be only passing `mempty` or `edit`.

For Pat's specific issue, we would have:

```haskell
instance HasDependencies MathQuestionContentEn
instance EntityKeyGen MathQuestionContentEn
...
Entity questionId _ <- node (only nf3SkillId) mempty
Entity contentId _ <- root $ keyed $ coerce questionId -- newtype
...
```
</details>

<details>
  <summary>
    Click here for older stuff
  </summary>

Specify `KeySource` in `HasDependencies`

This simplifies the `node` API even further. For a regular entity, a client now declares:

```haskell
mkPersist sqlSettings [persistLowerCase|
  Teacher
    name Text
    deriving Eq Show Generic

  Student
    name Text
    teacherId TeacherId Maybe
    deriving Eq Show Generic
|]

instance HasDependencies Teacher where
  type Dependencies Teacher = ()                 -- default
  type KeySource Teacher = 'GenerateKey 'Default -- default

instance HasDependencies Student where
  type Dependencies Student = Only (Maybe TeacherId)
  type KeySource Student = 'GenerateKey 'Default -- default
```

Using this information, we can statically assert that these values will always get their key from the database. We can use `node` as before to create entities:

```haskell
Entity teacherId _ <- node @Teacher $ edit $ \t -> t { teacherName = "Joe" }
Entity studentId _ <- node @Student (only $ Just teacherId) mempty
```

If we have a type with key that we'd rather generate with `Arbitrary` (e.g. a `UUID`), we can do like so:

```haskell
mkPersist sqlSettings [persistLowerCase|
  MathQuestion
    Id QuestionIdText
    skillId SkillId
    answerType AnswerType
    deriving Eq Show Generic
|]

deriving instance {-# OVERLAPPING #-} Arbitrary (Key MathQuestion)

instance HasDependencies MathQuestion where
  type Dependencies MathQuestion = Only SkillId
  type KeySource MathQuestion = 'GenerateKey 'Arbitrary
```

Again, `node` works as before, only we'll use `Arbitrary` ahead of time to create a key:

```haskell
Entity questionId _ <- node @MathQuestion (only skillId) mempty
```

Finally, if we have a type whose key should always be externally supplied, we do like so:

```haskell
mkPersist sqlSettings [persistLowerCase|
  MathQuestionContent
    Id QuestionIdText
    content Content
    deriving Eq Show Generic
|]

instance HasDependencies MathQuestionContent where
  type Dependencies MathQuestionContent = () -- default
  type KeySource MathQuestionContent = 'SpecifyKey
```

`node` will now require an extra argument following the type's dependencies:

```haskell
Entity questionId _ <- node @MathQuestion (only skillId) mempty
Entity contentId _ <- node @MathQuestionContent () (MathQuestionContentKey questionId) mempty
```

This uses some magic, but it's hopefully mostly hidden.

Also `GenEntityKey` is dead. `'GenerateKey 'Arbitrary` makes it redundant.

</details>

**NEWEST STUFF**

Specify `KeySource` in `HasDependencies` and split `node` into `node` and `nodeKeyed` (constraints elided):

```haskell
node      ::          Dependencies a -> NodeOptions a -> (m (Entity a))
nodeKeyed :: Key a -> Dependencies a -> NodeOptions a -> (m (Entity a))
```


For a regular entity, a client now declares:

```haskell
mkPersist sqlSettings [persistLowerCase|
  Teacher
    name Text
    deriving Eq Show Generic

  Student
    name Text
    teacherId TeacherId Maybe
    deriving Eq Show Generic
|]

instance HasDependencies Teacher where
  type Dependencies Teacher = ()           -- default
  type KeySource Teacher = 'SourceDefault  -- default

instance HasDependencies Student where
  type Dependencies Student = Only (Maybe TeacherId)
  type KeySource Student = 'SourceDefault  -- default
```

Using this information, we can statically assert that these values will always get their key from the database. We can use `node` as before to create entities:

```haskell
Entity teacherId _ <- node @Teacher $ edit $ \t -> t { teacherName = "Joe" }
Entity studentId _ <- node @Student (only $ Just teacherId) mempty
```

If we have a type with key that we'd rather generate with `Arbitrary` (e.g. a `UUID`), we can do like so:

```haskell
mkPersist sqlSettings [persistLowerCase|
  MathQuestion
    Id QuestionIdText
    skillId SkillId
    answerType AnswerType
    deriving Eq Show Generic
|]

deriving instance {-# OVERLAPPING #-} Arbitrary (Key MathQuestion)

instance HasDependencies MathQuestion where
  type Dependencies MathQuestion = Only SkillId
  type KeySource MathQuestion = 'SourceArbitrary
```

Again, `node` works as before, only we'll use `Arbitrary` ahead of time to create a key:

```haskell
Entity questionId _ <- node @MathQuestion (only skillId) mempty
```

Finally, if we have a type whose key should always be externally supplied, we do like so:

```haskell
mkPersist sqlSettings [persistLowerCase|
  MathQuestionContent
    Id QuestionIdText
    content Content
    deriving Eq Show Generic
|]

instance HasDependencies MathQuestionContent where
  type KeySource MathQuestionContent = 'SourceExternal
```

Now, the user cannot use `node` to create a value of type `MathQuestionContent`. This code:

```haskell
Entity questionId _ <- node @MathQuestion (only skillId) mempty
Entity contentId _ <- node @MathQuestionContent () mempty
```

will fail with an error message:

```plaintext
• Cannot generate a value of type ‘MathQuestionContent’ using ‘node’ since

    instance HasDependencies MathQuestionContent where
      type KeySource MathQuestionContent = 'SourceExternal

  Possible fixes include:
  • Use ‘nodeKeyed’ instead of ‘node’
  • Change ‘KeySource MathQuestionContent’ to 'SourceDefault or 'SourceArbitrary
    |
205 | Entity contentId _ <- node @MathQuestionContent () mempty
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
```

As suggested by the error message, the user must instead use `nodeKeyed`:

```haskell
Entity questionId _ <- node @MathQuestion (only skillId) mempty
Entity contentId _ <- nodeKeyed @MathQuestionContent (MathQuestionContentKey questionId) () mempty
```

`GenEntityKey` has been repurposed internally, and should no longer be implemented by the user.

### Alternatives

I briefly explored putting the dependencies inside `NodeOptions a`, but then you need to make sure there's no way _not_ to pass dependencies. [This requires more magic than I'm comforable with](https://gist.github.com/cdparks/08938203705df523b4a7102880030639).

A simpler model uses function application as the `(<>)` operator and makes the dependencies constructor (`with`) the only option that takes no arguments, e.g.:

```haskell
with     :: Dependencies a -> NodeOptions a
edit     :: (a -> a)       -> NodeOptions a -> NodeOptions a
suchThat :: (a -> Bool)    -> NodeOptions a -> NodeOptions a
keyed    :: Key a          -> NodeOptions a -> NodeOptions a

-- Then:

Entity schoolId _ <- root @School
Entity teacherId _ <- node @Teacher
  $ with (only $ Just schoolId)
  & keyed (TeacherKey 1)
  & edit (\s -> s { schoolName = "The School" })
```

Now we don't have to pass `mempty` everywhere, but we still need to over-parenthesize `edit` lambdas.