### PR TITLE
Remove Replay so we can remove JSON instance requirement

### DIFF
--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -13,8 +13,6 @@ library:
     - src
   ghc-options: -Wall
   dependencies:
-    - aeson
-    - bytestring
     - containers
     - directory
     - generics-eot

--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -24,6 +24,7 @@ library:
     - QuickCheck
     - semigroups
     - temporary
+    - text
     - transformers
     - unliftio
     - unliftio-core

--- a/graphula-core/test/README.lhs
+++ b/graphula-core/test/README.lhs
@@ -27,7 +27,6 @@ import Control.Monad.IO.Unlift
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT)
 import Control.Monad.Trans.Resource (ResourceT)
-import Data.Aeson
 import Database.Persist.Arbitrary ()
 import Database.Persist.Sqlite
 import Database.Persist.TH
@@ -149,26 +148,10 @@ that graphula will expect the database to provide a key.
 
 ## Serialization
 
-Graphula allows logging of graphs via `runGraphulaLogged`. We use `JSON` as a
-human readable serialization format. Graphula dumps graphs to a temp file on
-test failure.
+Graphula allows logging of graphs via `runGraphulaLogged`. Graphula dumps graphs
+to a temp file on test failure.
 
 ```haskell
-instance ToJSON A
-instance FromJSON A
-
-instance ToJSON B
-instance FromJSON B
-
-instance ToJSON C
-instance FromJSON C
-
-instance ToJSON D
-instance FromJSON D
-
-instance ToJSON E
-instance FromJSON E
-
 loggingSpec :: IO ()
 loggingSpec = do
   let


### PR DESCRIPTION
Changes:

- ff5e86f Remove Replay functionality

  Requiring that node types have JSON instances is problematic for us for
  nuanced, domain-specific reasons. By removing replay functionality, which we
  don't use, we believe we can then remove the JSON requirement by logging
  graphs, which we do use, as a serialization format that need not support
  de-serialization (e.g. `Show`).

  Ideally, this would be more directly configurable by end-users, such that
  anyone who wanted Replay could accept the JSON requirement, without forcing it
  on those that don't. But that is deferred for now since we are the only end
  users, as far as we know. (And it seemed mad hard yo.)

- 333f504 Use `Show`, not `ToJSON` in logging graph nodes

  **Concern**: we only write the graph to on failures, so performance at that
  step is probably not a concern, but we maintain the graph in the `IORef (Seq
  x)` all the time (AFAICT), so this will change what was `Seq Value` to `Seq
  Text` in an area that is exercised every test. That coo?

  I'm happy to use anything other than `Show` here. The requirements are:

  - Human readable
  - Isn't cumbersome for node types to implement
  - Isn't JSON ;)

  I picked `Show` since it's the least cumbersome thing for us to move to when
  this lands, as ~all our entities already have that instance. I'm also down to
  bring in (e.g.) `groom` to make the `Show`n values even more prettier, if we
  want.