### PR TITLE
Utilize stack local random generator

### DIFF
--- a/graphula-core/package.yaml
+++ b/graphula-core/package.yaml
@@ -20,6 +20,7 @@ library:
     - mtl
     - persistent
     - QuickCheck
+    - random
     - semigroups
     - temporary
     - text

--- a/graphula-core/src/Graphula.hs
+++ b/graphula-core/src/Graphula.hs
@@ -214,8 +214,8 @@ whenNothing (Just _) _ = pure Nothing
 
 runGraphulaT
   :: (MonadUnliftIO m)
-  => Maybe Int
-  -> (forall b . ReaderT SqlBackend n b -> m b)
+  => Maybe Int -- ^ Optional seed
+  -> (forall b . ReaderT SqlBackend n b -> m b) -- ^ Database runner
   -> GraphulaT n m a
   -> m a
 runGraphulaT mSeed runDB action = do

--- a/graphula-core/src/Graphula/Arbitrary.hs
+++ b/graphula-core/src/Graphula/Arbitrary.hs
@@ -1,0 +1,34 @@
+{-|
+  Graphula tracks its own 'QCGen' for deterministic generation with 'Arbitrary'
+  and 'Gen'. 'generate' can be used to produce arbitrary values utilizing
+  graphula's generation.
+-}
+module Graphula.Arbitrary
+  ( generate
+  )
+where
+
+import Prelude
+
+import Control.Monad.IO.Unlift (MonadIO, liftIO)
+import Data.IORef (readIORef, writeIORef)
+import Graphula.Internal (MonadGraphulaBackend, askGen)
+import System.Random (split)
+import Test.QuickCheck (Gen)
+import Test.QuickCheck.Gen (unGen)
+
+-- | Run a generator
+--
+-- This is akin to 'Test.QuickCheck.generate', but utilizing graphula's
+-- generation. The size passed to the generator is always 30; if you want
+-- another size then you should explicitly use 'Test.QuickCheck.resize'.
+--
+generate :: (MonadIO m, MonadGraphulaBackend m) => Gen a -> m a
+generate gen = do
+  genRef <- askGen
+  g <- liftIO $ readIORef genRef
+  let
+    (g1, g2) = split g
+    x = unGen gen g1 30
+  liftIO $ writeIORef genRef g2
+  pure x

--- a/graphula-core/src/Graphula/Internal.hs
+++ b/graphula-core/src/Graphula/Internal.hs
@@ -11,11 +11,21 @@
 
 module Graphula.Internal where
 
+import Data.IORef (IORef)
 import Data.Kind (Constraint, Type)
 import Database.Persist (Key)
 import Generics.Eot (Proxy(..), Void)
 import GHC.TypeLits (ErrorMessage(..), TypeError)
 import Test.QuickCheck (Arbitrary(..), Gen)
+import Test.QuickCheck.Random (QCGen)
+
+class MonadGraphulaBackend m where
+  type Logging m :: Type -> Constraint
+  -- ^ A constraint provided to log details of the graph to some form of
+  --   persistence. This is used by 'runGraphulaLogged' to store graph nodes as
+  --   'Show'n 'Text' values
+  askGen :: m (IORef QCGen)
+  logNode :: Logging m a => a -> m ()
 
 data Match t
   = NoMatch t

--- a/graphula-core/test/README.lhs
+++ b/graphula-core/test/README.lhs
@@ -157,7 +157,7 @@ loggingSpec = do
   let
     logFile = "test.graphula"
     -- We'd typically use `runGraphulaLogged` which utilizes a temp file.
-    failingGraph = runGraphulaT runDB . runGraphulaLoggedWithFileT logFile $ do
+    failingGraph = runGraphulaT Nothing runDB . runGraphulaLoggedWithFileT logFile $ do
       Entity _ a <- node @A () $ edit $ \n ->
         n {aA = "success"}
       liftIO $ aA a `shouldBe` "failed"
@@ -174,7 +174,7 @@ loggingSpec = do
 ```haskell
 simpleSpec :: IO ()
 simpleSpec =
-  runGraphulaT runDB $ do
+  runGraphulaT Nothing runDB $ do
     -- Declare the graph at the term level
     Entity aId _ <- node @A () mempty
     liftIO $ putStrLn "A"
@@ -211,7 +211,7 @@ instance MonadGraphulaFrontend (GraphulaFailT m) where
 insertionFailureSpec :: IO ()
 insertionFailureSpec = do
   let
-    failingGraph =  runGraphulaT runDB . runGraphulaFailT $ do
+    failingGraph =  runGraphulaT Nothing runDB . runGraphulaFailT $ do
       Entity _ _ <- node @A () mempty
       pure ()
   failingGraph
@@ -225,7 +225,7 @@ in the database:
 constraintFailureSpec :: IO ()
 constraintFailureSpec = do
   let
-    failingGraph =  runGraphulaT runDB $
+    failingGraph =  runGraphulaT Nothing runDB $
       replicateM_ 3 $ node @F () mempty
   failingGraph
     `shouldThrow` (== (GenerationFailureMaxAttemptsToInsert (typeRep $ Proxy @F)))
@@ -237,7 +237,7 @@ or if we define a graph with an unsatisfiable predicates:
 ensureFailureSpec :: IO ()
 ensureFailureSpec = do
   let
-    failingGraph =  runGraphulaT runDB $ do
+    failingGraph =  runGraphulaT Nothing runDB $ do
       Entity _ _ <- node @A () $ ensure $ \a -> a /= a
       pure ()
   failingGraph


### PR DESCRIPTION
Log based replay was removed from `graphula`. Log based replay was
necessary because random generation utilized non-deterministic `IO`.
Graphula can have deterministic random generation. Deterministic
generation allows seeds to be utilized for replay instead of logs.

- Deterministic generation requires holding onto a `QCGen` instance as
  state. This state is read, split and updated with every `generate` call.
- The `ReaderT` `IORef` pattern is used to allow `MonadUnliftIO`.
- The `Generate` associate type has been removed in favor of direct use
  of `Arbitrary`. `Arbitrary` has been used directly in graphula for a
  while now, via key generation. There is no reason to deny this fact
  with the complexity of an associated type.
- `withGraphulaT` now accepts an optional `seed`. Without the seed it
  uses `IO` to produce a random seed.
- On failure the seed is printed with the hunit failure.

This is in draft stage. If possible I'd like to figure out how to incorporate
`hspec`'s seed handling, which may mean the addition of a `graphula-hspec`
package. Though this is usable in its current state.