### PR TITLE
Remove cabal file from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.cabal
 *.stack-work
 :test:
 *.graphula

--- a/graphula-core/graphula-core.cabal
+++ b/graphula-core/graphula-core.cabal
@@ -1,0 +1,78 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 6d2c3c26856ffe4f969fae8c28e11aa6e252225226a3f13590d8526121438327
+
+name:           graphula-core
+version:        2.0.0.0
+maintainer:     Freckle Education
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    ../stack.yaml
+
+library
+  exposed-modules:
+      Graphula
+      Graphula.Arbitrary
+      Graphula.Internal
+      Graphula.Key
+  other-modules:
+      Paths_graphula_core
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      HUnit
+    , QuickCheck
+    , base
+    , containers
+    , directory
+    , generics-eot
+    , mtl
+    , persistent
+    , random
+    , semigroups
+    , temporary
+    , text
+    , transformers
+    , unliftio
+    , unliftio-core
+  default-language: Haskell2010
+
+test-suite readme
+  type: exitcode-stdio-1.0
+  main-is: README.lhs
+  other-modules:
+      Graphula.UUIDKey
+      Paths_graphula_core
+  hs-source-dirs:
+      test
+  ghc-options: -Wall -pgmL markdown-unlit
+  build-depends:
+      QuickCheck
+    , aeson
+    , base
+    , bytestring
+    , containers
+    , graphula-core
+    , hspec
+    , http-api-data
+    , markdown-unlit
+    , monad-logger
+    , path-pieces
+    , persistent
+    , persistent-arbitrary
+    , persistent-sqlite
+    , persistent-template
+    , resourcet
+    , semigroups
+    , text
+    , transformers
+    , unliftio-core
+    , uuid
+  default-language: Haskell2010

--- a/persistent-arbitrary/persistent-arbitrary.cabal
+++ b/persistent-arbitrary/persistent-arbitrary.cabal
@@ -1,0 +1,30 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: e3dd0b7ad844e3ad021b916dbd994c2a465856dcda816606b0b639116db5b875
+
+name:           persistent-arbitrary
+version:        0.1.0
+maintainer:     Front Row Education
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    ../stack.yaml
+
+library
+  exposed-modules:
+      Database.Persist.Arbitrary
+  other-modules:
+      Paths_persistent_arbitrary
+  hs-source-dirs:
+      src
+  ghc-options: -Wall
+  build-depends:
+      QuickCheck
+    , base
+    , persistent
+  default-language: Haskell2010


### PR DESCRIPTION
Addresses: https://github.com/freckle/graphula/issues/45

https://github.com/commercialhaskell/stack/issues/5210

The stack team is now recommending that projects store their cabal file
instead of utilizing just `hpack` generation.