### PR TITLE
Rename package to just graphula

### DIFF
--- a/graphula.cabal
+++ b/graphula.cabal
@@ -4,9 +4,9 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0b3346ba04119033e16ceed79b0bf57f23ff4a24c0de9cabae469d7f73873b57
+-- hash: 27527492b3fc116beed47b45112585e94cd1d60ba36588977e88f5e43018256a
 
-name:           graphula-core
+name:           graphula
 version:        2.0.0.1
 synopsis:       A declarative library for describing dependencies between data
 description:    Please see README.md
@@ -32,7 +32,7 @@ library
       Graphula.Internal
       Graphula.Key
   other-modules:
-      Paths_graphula_core
+      Paths_graphula
   hs-source-dirs:
       src
   ghc-options: -Weverything -Wno-unsafe -Wno-safe -Wno-missing-import-lists -Wno-implicit-prelude
@@ -59,7 +59,7 @@ test-suite readme
   main-is: README.lhs
   other-modules:
       Graphula.UUIDKey
-      Paths_graphula_core
+      Paths_graphula
   hs-source-dirs:
       test
   ghc-options: -Weverything -Wno-unsafe -Wno-safe -Wno-missing-import-lists -Wno-implicit-prelude -pgmL markdown-unlit
@@ -69,7 +69,7 @@ test-suite readme
     , base
     , bytestring
     , containers
-    , graphula-core
+    , graphula
     , hspec
     , http-api-data
     , markdown-unlit

--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,7 @@ tests:
       - aeson
       - bytestring
       - containers
-      - graphula-core
+      - graphula
       - hspec
       - http-api-data
       - markdown-unlit

--- a/package.yaml
+++ b/package.yaml
@@ -1,4 +1,4 @@
-name: graphula-core
+name: graphula
 version: 2.0.0.1
 maintainer: Freckle Education
 category: Network

--- a/test/README.lhs
+++ b/test/README.lhs
@@ -252,7 +252,7 @@ ensureFailureSpec = do
 ```haskell
 main :: IO ()
 main = hspec $
-  describe "graphula-core" . parallel $ do
+  describe "graphula" . parallel $ do
     it "generates and links arbitrary graphs of data" simpleSpec
     it "allows logging graphs" loggingSpec
     it "attempts to retry node generation on insertion failure" insertionFailureSpec


### PR DESCRIPTION
There is no `graphula-{not core}` anymore, so the `-core` is superfluous. I had
intended to upload this package to Hackage as graphula, but missed this little
`name`.

I assume I can just re-release like this to create `graphula` on Hackage too,
but what do I do with the `graphula-core` there now?