### PR TITLE
Add workflow to release to Hackage on tag creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+name: Release to Hackage
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      HACKAGE_API_KEY: ${{ secrets.HACKAGE_API_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: freckle/stack-upload-action@main
+        with:
+          pvp-bounds: both


### PR DESCRIPTION
Most of the logic is in the action repository, and it'll get tested after I
merge this and attempt to release 2.0.0.4 by pushing the tag.

It uses an API Key I created for the FreckleEngineering user, which we'll
add as maintainer to all our packages, and stored as an Organization secret in
Freckle.

This does regress a little bit on the checks I'd typically do as part of
releasing (e.g. does it build on stackage-nightly), but I hope to bring those
into the normal CI workflow(s).

Additionally, if we can get a merge to `main` that signals a release to create
an appropriate tag, that would close the loop and automate everything
end-to-end.