### PR TITLE
Bump persistent bounds

### DIFF
--- a/graphula.cabal
+++ b/graphula.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 01e24f405fec0dcdc8ccfd0f47236b9cc2b9ae1252767b7ec77ea97742778b9d
+-- hash: e3d950a78bbdb0295443b2d0eb3009ef8644d9f40b31da51bdd43c41ca630571
 
 name:           graphula
 version:        2.0.0.4
@@ -44,7 +44,7 @@ library
     , directory
     , generics-eot
     , mtl
-    , persistent <2.13
+    , persistent <2.14
     , random <1.3
     , semigroups
     , temporary

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,7 @@ library:
     - directory
     - generics-eot
     - mtl
-    - persistent < 2.13
+    - persistent < 2.14
     - random < 1.3
     - semigroups
     - temporary


### PR DESCRIPTION
graphula works fine with the new version of persistent, so I'm just relaxing the bounds.