### PR TITLE
Add missing MonadUnliftIO instance to GraphulaLoggedT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 None
 
+## [v2.0.2.2](https://github.com/freckle/graphula/compare/v2.0.2.1...v2.0.2.2)
+
+- Add missing MonadUnliftIO instance to GraphulaLoggedT
+
 ## [v2.0.2.1](https://github.com/freckle/graphula/compare/v2.0.1.1...v2.0.2.1)
 
 - Support persistent-2.14

--- a/graphula.cabal
+++ b/graphula.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4a8b65b0eb39f3dae910f6cf85ef121a3b518aac75e68d65d13057c169b73681
+-- hash: e974379647c8b19b84f448686faab064910805de194b9f7e13bdd81d64b2014a
 
 name:           graphula
-version:        2.0.2.1
+version:        2.0.2.2
 synopsis:       A simple interface for generating persistent data and linking its dependencies
 description:    Please see README.md
 category:       Network

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: graphula
-version: 2.0.2.1
+version: 2.0.2.2
 maintainer: Freckle Education
 category: Network
 github: freckle/graphula

--- a/src/Graphula/Logged.hs
+++ b/src/Graphula/Logged.hs
@@ -50,6 +50,7 @@ newtype GraphulaLoggedT m a = GraphulaLoggedT
     , Applicative
     , Monad
     , MonadIO
+    , MonadUnliftIO
     , MonadReader (IORef (Seq Text))
     )
 

--- a/src/Graphula/Logged.hs
+++ b/src/Graphula/Logged.hs
@@ -50,9 +50,13 @@ newtype GraphulaLoggedT m a = GraphulaLoggedT
     , Applicative
     , Monad
     , MonadIO
-    , MonadUnliftIO
     , MonadReader (IORef (Seq Text))
     )
+
+instance MonadUnliftIO m => MonadUnliftIO (GraphulaLoggedT m) where
+  {-# INLINE withRunInIO #-}
+  withRunInIO inner =
+    GraphulaLoggedT $ withRunInIO $ \run -> inner $ run . runGraphulaLoggedT'
 
 instance MonadTrans GraphulaLoggedT where
   lift = GraphulaLoggedT . lift


### PR DESCRIPTION
This transformer was missed when adding `MonadUnliftIO` instances.