### PR TITLE
Add a comment about ordering in NodeOptions

### DIFF
--- a/src/Graphula/Node.hs
+++ b/src/Graphula/Node.hs
@@ -59,6 +59,10 @@ import UnliftIO.Exception (Exception, throwIO)
 -- > a1 <- node @A () mempty
 -- > a2 <- node @A () $ edit $ \a -> a { someField = True }
 -- > a3 <- node @A () $ ensure $ (== True) . someField
+--
+-- The Semigroup orders the operations from right to left. For example,
+-- @edit z <> ensure y <> edit x@ first performs edit @x@, then fails if
+-- the value does not satisfy assertion @y@, then performs edit @z@.
 newtype NodeOptions a = NodeOptions
   { nodeOptionsEdit :: Kendo Maybe a
   }

--- a/src/Graphula/Node.hs
+++ b/src/Graphula/Node.hs
@@ -61,8 +61,8 @@ import UnliftIO.Exception (Exception, throwIO)
 -- > a3 <- node @A () $ ensure $ (== True) . someField
 --
 -- The Semigroup orders the operations from right to left. For example,
--- @edit z <> ensure y <> edit x@ first performs edit @x@, then fails if
--- the value does not satisfy assertion @y@, then performs edit @z@.
+-- @'edit' z <> 'ensure' y <> 'edit' x@ first performs @'edit' x@, then fails if
+-- the value does not satisfy assertion @y@, then performs @'edit' z@.
 newtype NodeOptions a = NodeOptions
   { nodeOptionsEdit :: Kendo Maybe a
   }


### PR DESCRIPTION
Sometimes we have test utilities that accept some node options and also apply their own defaults, and so I was wondering the right ordering so that overrides could come after the defaults in the event that some options conflict.
