### PR TITLE
chore(release): use published semantic-release plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
-            git+https://github.com/pbrisbin/semantic-release-stack-upload.git
+            semantic-release-stack-upload
         env:
           FORCE_COLOR: 1
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
This has been released on npm, so we no longer need the git reference.
The git reference doesn't work, in fact, because once released I stopped
committing `dist/` to version control.
