### PR TITLE
feat: export EntityKeys

### DIFF
--- a/src/Graphula/Key.hs
+++ b/src/Graphula/Key.hs
@@ -6,9 +6,8 @@
 
 -- | Convenience functions for working with 'Key' dependencies
 module Graphula.Key
-  ( onlyKey
-  , keys
-  , Keys
+  ( EntityKeys(..)
+  , onlyKey
   ) where
 
 import Database.Persist


### PR DESCRIPTION
The member and associated type were already exported, so this is
strictly an addition. Now, users can express type signatures using this
class, as well as make their own instances.

Closes #90.
