### PR TITLE
feat: include insert error messages in GenerationFailure

### DIFF
--- a/src/Graphula/Class.hs
+++ b/src/Graphula/Class.hs
@@ -66,6 +66,18 @@ class MonadGraphulaFrontend m where
     => Maybe (Key a)
     -> a
     -> m (Maybe (Entity a))
+  insert mk a = either (const Nothing) Just <$> insertEither mk a
+
+  insertEither
+    :: ( PersistEntityBackend a ~ SqlBackend
+       , PersistEntity a
+       , Monad m
+       , GraphulaSafeToInsert a
+       )
+    => Maybe (Key a)
+    -> a
+    -> m (Either String (Entity a))
+  insertEither mk a = maybe (Left "Unable to insert entity") Right <$> insert mk a
 
   insertKeyed
     :: ( PersistEntityBackend a ~ SqlBackend
@@ -75,11 +87,24 @@ class MonadGraphulaFrontend m where
     => Key a
     -> a
     -> m (Maybe (Entity a))
+  insertKeyed k a = either (const Nothing) Just <$> insertKeyedEither k a
+
+  insertKeyedEither
+    :: ( PersistEntityBackend a ~ SqlBackend
+       , PersistEntity a
+       , Monad m
+       )
+    => Key a
+    -> a
+    -> m (Either String (Entity a))
+  insertKeyedEither k a = maybe (Left "Unable to insert keyed entity") Right <$> insertKeyed k a
 
   remove
     :: (PersistEntityBackend a ~ SqlBackend, PersistEntity a, Monad m)
     => Key a
     -> m ()
+
+  {-# MINIMAL (insert | insertEither), (insertKeyed | insertKeyedEither), remove #-}
 
 class MonadGraphulaBackend m where
   type Logging m :: Type -> Constraint

--- a/src/Graphula/Dependencies.hs
+++ b/src/Graphula/Dependencies.hs
@@ -107,10 +107,10 @@ class HasDependencies a where
     :: ( HasEot a
        , HasEot (Dependencies a)
        , GHasDependencies
-          (Proxy a)
-          (Proxy (Dependencies a))
-          (Eot a)
-          (Eot (Dependencies a))
+           (Proxy a)
+           (Proxy (Dependencies a))
+           (Eot a)
+           (Eot (Dependencies a))
        )
     => a
     -> Dependencies a
@@ -177,16 +177,28 @@ class InsertWithPossiblyRequiredKey (requirement :: Type -> Type) where
     => requirement (Key record)
     -> record
     -> m (Maybe (Entity record))
+  insertWithPossiblyRequiredKeyEither
+    :: ( PersistEntityBackend record ~ SqlBackend
+       , PersistEntity record
+       , Monad m
+       , MonadGraphulaFrontend m
+       , InsertConstraint requirement record
+       )
+    => requirement (Key record)
+    -> record
+    -> m (Either String (Entity record))
   justKey :: key -> requirement key
 
 instance InsertWithPossiblyRequiredKey Optional where
   type InsertConstraint Optional = GraphulaSafeToInsert
   insertWithPossiblyRequiredKey (Optional key) = MonadGraphulaFrontend.insert key
+  insertWithPossiblyRequiredKeyEither (Optional key) = MonadGraphulaFrontend.insertEither key
   justKey = Optional . Just
 
 instance InsertWithPossiblyRequiredKey Required where
   type InsertConstraint Required = NoConstraint
   insertWithPossiblyRequiredKey (Required key) = MonadGraphulaFrontend.insertKeyed key
+  insertWithPossiblyRequiredKeyEither (Required key) = MonadGraphulaFrontend.insertKeyedEither key
   justKey = Required
 
 -- | Abstract constraint that some @a@ can generate a key


### PR DESCRIPTION
This adds `*Either` versions of our two insert functions in the frontend
class, which return `Left String` errors, rather than `Nothing`s.

We define the maybe and either versions in terms of each other, making
this a backwards-compatible change, and use `MINIMAL` to ensure one or
the other always gets defined.

Then, we update our own instance to define either variants, with
informative messages for the failing cases.

Lastly, by using those either variants within the main loop, we can
collect (at least the final) `Left` value and report it as part of the
`GenerationFailure`.

The new README test confirms it works and shows what such an exception
will look like now.

Fixes #17.
