### PR TITLE
Move markdown-unlit to build-tools

### DIFF
--- a/test/README.lhs
+++ b/test/README.lhs
@@ -45,7 +45,6 @@ import Graphula
 import Test.Hspec
 import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
-import Text.Markdown.Unlit ()
 
 instance (ToBackendKey SqlBackend a) => Arbitrary (Key a) where
   arbitrary = toSqlKey <$> arbitrary


### PR DESCRIPTION
## Summary

This PR moves `markdown-unlit` from `dependencies` to `build-tools` in the package.yaml test configuration and removes the corresponding empty import from README.lhs.

## Why this change?

When `markdown-unlit` is listed in `dependencies`, we need to import it in the Haskell code to avoid unused-package warnings from GHC. However, since `markdown-unlit` is only used as a preprocessor (via `-pgmL markdown-unlit`), we don't actually need to import anything from it in our code.

By moving it to `build-tools` instead, we:
- Avoid unused-package warnings without needing empty imports
- Make the dependency relationship clearer (it's a build tool, not a runtime dependency)
- Follow Stack/Cabal best practices for preprocessor dependencies

## Changes

- Moved `markdown-unlit` from `dependencies` to `build-tools` in package.yaml
- Removed `import Text.Markdown.Unlit ()` from README.lhs
- Regenerated any files via `stack build --fast --test --no-run-tests`

🤖 Generated with Claude Code