### PR TITLE
Move markdown-unlit to build-tools

### DIFF
--- a/graphula.cabal
+++ b/graphula.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -78,13 +78,14 @@ test-suite readme
   hs-source-dirs:
       test
   ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-implicit-prelude -Wno-missing-import-lists -Wno-safe -Wno-unsafe -pgmL markdown-unlit
+  build-tool-depends:
+      markdown-unlit:markdown-unlit
   build-depends:
       QuickCheck
     , base <5
     , generic-arbitrary
     , graphula
     , hspec
-    , markdown-unlit
     , monad-logger
     , persistent
     , persistent-sqlite

--- a/package.yaml
+++ b/package.yaml
@@ -9,7 +9,6 @@ description: Please see README.md
 extra-source-files:
   - README.md
   - CHANGELOG.md
-
 ghc-options:
   - -Weverything
   - -Wno-all-missed-specialisations
@@ -17,7 +16,6 @@ ghc-options:
   - -Wno-missing-import-lists
   - -Wno-safe
   - -Wno-unsafe
-
 when:
   - condition: impl(ghc >= 9.8)
     ghc-options:
@@ -33,10 +31,8 @@ when:
   - condition: impl(ghc < 8.6)
     ghc-options:
       - -Wno-redundant-constraints
-
 dependencies:
   - base < 5
-
 library:
   source-dirs:
     - src
@@ -54,27 +50,23 @@ library:
     - text
     - unliftio
     - unliftio-core
-
 tests:
   readme:
     main: README.lhs
     ghc-options: -pgmL markdown-unlit
     source-dirs:
       - test
-
     dependencies:
       - QuickCheck
       - generic-arbitrary
       - graphula
       - hspec
-      - markdown-unlit
       - monad-logger
       - persistent
       - persistent-sqlite
       - resourcet
       - transformers
       - unliftio-core
-
     when:
       - condition: impl(ghc >= 8.8)
         ghc-options:
@@ -82,7 +74,8 @@ tests:
       - condition: "flag(persistent-template)"
         dependencies:
           - persistent-template
-
+    build-tools:
+      - markdown-unlit
 flags:
   persistent-template:
     description: Include dependency on persistent-template

--- a/test/README.lhs
+++ b/test/README.lhs
@@ -45,7 +45,6 @@ import Graphula
 import Test.Hspec
 import Test.QuickCheck
 import Test.QuickCheck.Arbitrary.Generic
-import Text.Markdown.Unlit ()
 
 instance (ToBackendKey SqlBackend a) => Arbitrary (Key a) where
   arbitrary = toSqlKey <$> arbitrary


### PR DESCRIPTION
## Summary

This PR moves `markdown-unlit` from `dependencies` to `build-tools` in the package.yaml test configuration and removes the corresponding empty import from README.lhs.

## Why this change?

When `markdown-unlit` is listed in `dependencies`, we need to import it in the Haskell code to avoid unused-package warnings from GHC. However, since `markdown-unlit` is only used as a preprocessor (via `-pgmL markdown-unlit`), we don't actually need to import anything from it in our code.

By moving it to `build-tools` instead, we:
- Avoid unused-package warnings without needing empty imports
- Make the dependency relationship clearer (it's a build tool, not a runtime dependency)
- Follow Stack/Cabal best practices for preprocessor dependencies

## Changes

- Moved `markdown-unlit` from `dependencies` to `build-tools` in package.yaml
- Removed `import Text.Markdown.Unlit ()` from README.lhs
- Regenerated any files via `stack build --fast --test --no-run-tests`

🤖 Generated with Claude Code